### PR TITLE
Added stdin reading capability to amqpsend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ You may also pass a filename as input.
   
 $ ./amqpsend --help::
   
-  Usage: ./amqpsend [options] exchange routingkey [msg]
+  Usage: ./amqpsend [options] exchange routingkey [message]
   Options:
     --host/-h host         specify the host (default: "amqpbroker")
     --port/-P port         specify AMQP port (default: 5672)
@@ -71,8 +71,12 @@ $ ./amqpsend --help::
   The following environment variables may also be set:
     AMQP_HOST, AMQP_PORT, AMQP_VHOST, AMQP_USER, AMQP_PASSWORD, AMQP_PERSISENT
   Acceptable values for AMQP_PERSISENT are '1' (No Persist) and '2' (Persist)
+
+  With no -f option and no message, message contents will be read from standard
+  input. 
   
   Example:
   $ amqpsend -h amqp.example.com -P 5672 amq.fanout mykey "HELLO AMQP"
   $ amqpsend -h amqp.example.com -P 5672 amq.fanout mykey -f /etc/hosts
+  $ echo "HELLO AMQP" | amqpsend -h amqp.example.com -P 5672 amq.fanout mykey
   


### PR DESCRIPTION
I added the option to leave out the filename and the command line message and instead read the message body from standard input.

I performed regression testing to make sure the previous options still behaved generally as expected.  The primary difference is where the help message was printed if the filename option and command-line message argument were missing.

Additional testing included sending of large files (20M) to test buffer reallocations.  I did not do any performance analysis using the read buffer of only 8K.

Feel free to not accept these changes as you see fit.  I made them for my own use and wish to give you the option to make them generally available in your project if you deem it desirable to do so.

Thank you.
