### PR TITLE
add LD_RUN_PATH to makefile to link to the rabbitmq lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ ifeq (${AMQPTOOLS_INSTALLROOT},)
     AMQPTOOLS_INSTALLROOT = "/usr/local/bin"
 endif
 
+LD_RUN_PATH = $(realpath $(AMQPTOOLS_RABBITHOME)/librabbitmq/.libs)
+export LD_RUN_PATH
 
 all: clean build
 


### PR DESCRIPTION
according to this:

http://osr507doc.sco.com/en/tools/ccs_linkedit_dynamic_dirsearch.html

its possible to add the LD_RUN_PATH while linking to avoid setting the LD_LIBRARY_PATH on runtime.

In my case (on debian) the static linking did not work out of the box. This is what i found:

```
If you ever happen to want to link against installed libraries
in a given directory, LIBDIR, you must either use libtool, and
specify the full pathname of the library, or use the `-LLIBDIR'
flag during linking and do at least one of the following:
   - add LIBDIR to the `LD_LIBRARY_PATH' environment variable
     during execution
   - add LIBDIR to the `LD_RUN_PATH' environment variable
     during linking
   - use the `-Wl,-rpath -Wl,LIBDIR' linker flag
   - have your system administrator add LIBDIR to `/etc/ld.so.conf'

See any operating system documentation about shared libraries for
more information, such as the ld(1) and ld.so(8) manual pages.
```

hope this helps.

best regards
Philipp
